### PR TITLE
FEATURES: Loaders Blade components

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,3 +284,29 @@ To use the Split Carousel and Split Slide component, add the following markup to
 - `class` - Any classes you want to apply to the element around the slot. This should be used to pass in the height classes.
 
 Any additional attributes you add to the Split Slide component (`style`, etc.), will be passed through to the background element.
+
+### Loaders
+
+To use the Loader component, light or dark, add the following markup to your Blade template.
+
+#### Light
+```blade
+<x-kernl-loaders.light
+    x-show="busy"
+/>
+```
+
+#### Dark
+```blade
+<x-kernl-loaders.light
+    x-show="busy"
+/>
+```
+
+#### `x-kernl-loaders.light` Props
+
+- `x-show` - (optional) Used to show/hide the loader based on an AlpineJs property
+
+#### `x-kernl-loaders.dark` Props
+
+- `x-show` - (optional) Used to show/hide the loader based on an AlpineJs property

--- a/src/Components/Loaders/Dark.php
+++ b/src/Components/Loaders/Dark.php
@@ -1,0 +1,13 @@
+<?php
+namespace Northeastern\Blade\Components\Loaders;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
+
+class Dark extends Component
+{
+    public function render()
+    {
+        return View::make('kernl-ui::loaders.dark');
+    }
+}

--- a/src/Components/Loaders/Light.php
+++ b/src/Components/Loaders/Light.php
@@ -1,0 +1,13 @@
+<?php
+namespace Northeastern\Blade\Components\Loaders;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
+
+class Light extends Component
+{
+    public function render()
+    {
+        return View::make('kernl-ui::loaders.light');
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -14,6 +14,8 @@ use Northeastern\Blade\Components\Carousel\Base as CarouselBase;
 use Northeastern\Blade\Components\Carousel\Base\Slide as CarouselBaseSlide;
 use Northeastern\Blade\Components\Carousel\Split as CarouselSplit;
 use Northeastern\Blade\Components\Carousel\Split\Slide as CarouselSplitSlide;
+use Northeastern\Blade\Components\Loaders\Dark as LoadersDark;
+use Northeastern\Blade\Components\Loaders\Light as LoadersLight;
 use Northeastern\Blade\Components\LocalHeader;
 
 class ServiceProvider extends BaseServiceProvider
@@ -31,5 +33,8 @@ class ServiceProvider extends BaseServiceProvider
         CarouselBaseSlide::class => 'kernl-carousel.base.slide',
         CarouselSplit::class => 'kernl-carousel.split',
         CarouselSplitSlide::class => 'kernl-carousel.split.slide',
+
+        LoadersLight::class => 'kernl-loaders.light',
+        LoadersDark::class => 'kernl-loaders.dark',
     ];
 }

--- a/src/views/loaders/dark.blade.php
+++ b/src/views/loaders/dark.blade.php
@@ -1,0 +1,13 @@
+<div
+    {{ $attributes->whereStartsWith('x-show') }}
+    class="absolute inset-0 flex items-center justify-center transform"
+    x-transition:enter="transition ease-in-out duration-300"
+    x-transition:enter-start="transform opacity-0"
+    x-transition:leave="transition ease-in-out duration-300"
+    x-transition:leave-end="transform opacity-0"
+>
+    <!-- Semi-transparent overlay -->
+    <div class="absolute inset-0 bg-black bg-opacity-40"></div>
+    <!-- Loading spinner -->
+    <i data-feather="loader" aria-label="Loading" class="w-6 h-6 animate-spin text-white"></i>
+</div>

--- a/src/views/loaders/light.blade.php
+++ b/src/views/loaders/light.blade.php
@@ -1,0 +1,13 @@
+<div
+    {{ $attributes->whereStartsWith('x-show') }}
+    class="absolute inset-0 flex items-center justify-center transform"
+    x-transition:enter="transition ease-in-out duration-300"
+    x-transition:enter-start="transform opacity-0"
+    x-transition:leave="transition ease-in-out duration-300"
+    x-transition:leave-end="transform opacity-0"
+>
+    <!-- Semi-transparent overlay -->
+    <div class="absolute inset-0 bg-white bg-opacity-40"></div>
+    <!-- Loading spinner -->
+    <i data-feather="loader" aria-label="Loading" class="w-6 h-6 animate-spin text-gray-600"></i>
+</div>


### PR DESCRIPTION
## Summary

This PR adds Blade components for light/dark loader styles

For each style, a Component class was added.

README was updated with usage instructions.

## Proposed api:
```blade

<x-kernl-loaders.light
    x-show="busy"
/>

<x-kernl-loaders.dark
    x-show="busy"
/>
```

## Example

![image](https://user-images.githubusercontent.com/5126648/105412540-e36a0c00-5c02-11eb-9540-a7359c8f9a81.png)

## Type of Change

- [x] 🚀 New Feature

## Screenshot/Video

![2021-01-21 16 05 41](https://user-images.githubusercontent.com/5126648/105412423-b9b0e500-5c02-11eb-8d7c-d5d5de8244df.gif)
