### PR TITLE
FEATURES: Banner Blade components

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,3 +284,39 @@ To use the Split Carousel and Split Slide component, add the following markup to
 - `class` - Any classes you want to apply to the element around the slot. This should be used to pass in the height classes.
 
 Any additional attributes you add to the Split Slide component (`style`, etc.), will be passed through to the background element.
+
+
+### Banners
+
+### With Offset Card
+
+To use the With Offset Card Banner component, add the following markup to your Blade template.
+
+```blade
+<x-kernl-banners.with-offset-card
+    :background-url="''"
+>
+    {{--Card content goes here--}}
+</x-kernl-banners.with-offset-card>
+```
+
+#### `x-kernl-banners.with-offset-card` Props
+
+- `background-url` - Url of background image to be applied. 
+
+
+### Bottom Title
+
+To use the Bottom Title Banner component, add the following markup to your Blade template.
+
+```blade
+<x-kernl-banners.bottom-title
+    :background-url="''"
+    :title="''"
+/>
+```
+
+#### `x-kernl-banners.bottom-title` Props
+
+- `background-url` - Url of background image to be applied. 
+- `title` - Title to be presented. 

--- a/src/Components/Banners/BottomTitle.php
+++ b/src/Components/Banners/BottomTitle.php
@@ -10,8 +10,10 @@ class BottomTitle extends Component
 
     public $backgroundUrl;
 
-    public function __construct($title = null,
-                                $backgroundUrl = null)
+    public function __construct(
+        $title = null,
+        $backgroundUrl = null
+    )
     {
         $this->title = $title;
         $this->backgroundUrl = $backgroundUrl;

--- a/src/Components/Banners/BottomTitle.php
+++ b/src/Components/Banners/BottomTitle.php
@@ -1,0 +1,24 @@
+<?php
+namespace Northeastern\Blade\Components\Banners;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
+
+class BottomTitle extends Component
+{
+    public $title;
+
+    public $backgroundUrl;
+
+    public function __construct($title = null,
+                                $backgroundUrl = null)
+    {
+        $this->title = $title;
+        $this->backgroundUrl = $backgroundUrl;
+    }
+
+    public function render()
+    {
+        return View::make('kernl-ui::banners.bottom-title');
+    }
+}

--- a/src/Components/Banners/BottomTitle.php
+++ b/src/Components/Banners/BottomTitle.php
@@ -13,8 +13,7 @@ class BottomTitle extends Component
     public function __construct(
         $title = null,
         $backgroundUrl = null
-    )
-    {
+    ) {
         $this->title = $title;
         $this->backgroundUrl = $backgroundUrl;
     }

--- a/src/Components/Banners/WithOffsetCard.php
+++ b/src/Components/Banners/WithOffsetCard.php
@@ -1,0 +1,20 @@
+<?php
+namespace Northeastern\Blade\Components\Banners;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
+
+class WithOffsetCard extends Component
+{
+    public $backgroundUrl;
+
+    public function __construct($backgroundUrl = null)
+    {
+        $this->backgroundUrl = $backgroundUrl;
+    }
+
+    public function render()
+    {
+        return View::make('kernl-ui::banners.with-offset-card');
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -8,6 +8,8 @@ use Northeastern\Blade\Components\Accordion\Item as AccordionItem;
 use Northeastern\Blade\Components\Accordion\WithLeftIcon as AccordionWithLeftIcon;
 use Northeastern\Blade\Components\Alert\Contained as AlertContained;
 use Northeastern\Blade\Components\Alert\FullWidth as AlertFullWidth;
+use Northeastern\Blade\Components\Banners\BottomTitle as BannersBottomTitle;
+use Northeastern\Blade\Components\Banners\WithOffsetCard as BannersWithOffsetCard;
 use Northeastern\Blade\Components\Button\Outline as ButtonOutline;
 use Northeastern\Blade\Components\Button\Solid as ButtonSolid;
 use Northeastern\Blade\Components\Carousel\Base as CarouselBase;
@@ -31,5 +33,8 @@ class ServiceProvider extends BaseServiceProvider
         CarouselBaseSlide::class => 'kernl-carousel.base.slide',
         CarouselSplit::class => 'kernl-carousel.split',
         CarouselSplitSlide::class => 'kernl-carousel.split.slide',
+
+        BannersWithOffsetCard::class => 'kernl-banners.with-offset-card',
+        BannersBottomTitle::class => 'kernl-banners.bottom-title',
     ];
 }

--- a/src/views/banners/bottom-title.blade.php
+++ b/src/views/banners/bottom-title.blade.php
@@ -1,0 +1,10 @@
+<div
+    class="pt-48 bg-black bg-center bg-cover bg-no-repeat md:pt-64"
+    style="background-image: url('{{ $backgroundUrl }}')"
+>
+    <div class="container py-6 text-white bg-black bg-opacity-80">
+        <h2 class="text-2xl leading-tight sm:text-3xl md:text-4xl lg:text-5xl">
+            {{ $title }}
+        </h2>
+    </div>
+</div>

--- a/src/views/banners/with-offset-card.blade.php
+++ b/src/views/banners/with-offset-card.blade.php
@@ -1,0 +1,10 @@
+<div
+    class="py-16 bg-black bg-center bg-cover bg-no-repeat md:py-20"
+    style="background-image: url('{{ $backgroundUrl }}')"
+>
+    <div class="container">
+        <div class="max-w-2xl px-6 py-12 text-white bg-black bg-opacity-80 lg:px-12 lg:py-16">
+            {{ $slot }}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

This PR adds Blade components for following Banner styles:
- With Offset Card
- Bottom Title

For each style, a Component class was added.

README was updated with usage instructions.

## Proposed api:
```blade
<x-kernl-banners.with-offset-card
    :background-url="''"
>
    Content here
</x-kernl-banners.with-offset-card>

<x-kernl-banners.bottom-title
    :background-url="''"
    :title="''"
/>
```

## Example

![image](https://user-images.githubusercontent.com/5126648/105415762-2b8b2d80-5c07-11eb-843d-b857ee5c9e12.png)

## Type of Change

- [x] 🚀 New Feature

## Screenshot/Video

<img width="1047" alt="Screen Shot 2021-01-21 at 4 36 41 PM" src="https://user-images.githubusercontent.com/5126648/105415636-fc74bc00-5c06-11eb-9f1d-47b1115ef04f.png">
