### PR TITLE
FEATURES: Modals components

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,3 +284,28 @@ To use the Split Carousel and Split Slide component, add the following markup to
 - `class` - Any classes you want to apply to the element around the slot. This should be used to pass in the height classes.
 
 Any additional attributes you add to the Split Slide component (`style`, etc.), will be passed through to the background element.
+
+
+### Modals
+
+### Base Modal
+
+To use the Base Modal component, add the following markup to your Blade template.
+
+```blade
+<x-kernl-modals.base
+    :modal-id="''"
+    :closeable="true|false"
+    :close-on-click-outside="true|false"
+    :close-on-escape-key="true|false"
+>
+    {{-- Content here --}}
+</x-kernl-modals.base>
+```
+
+#### `x-kernl-modals.base` Props
+
+- `modal-id` - Id of the modal. Must be unique throughout the app. This id can be used with `window.NUModals` methods
+- `closeable` - (optional) Adds close button at the top right corner. `true` by default
+- `close-on-click-outside` - (optional) Adds behavior to close when clicking outside the modal. `true` by default
+- `close-on-escape-key` - (optional) Adds behavior to close when pressing the Esc key. `true` by default

--- a/README.md
+++ b/README.md
@@ -395,27 +395,29 @@ To use the Outline Tag component, add the following markup to your Blade templat
 - `pill` - (optional) Rounds corners for a pill-like appearance. Default is `false`
 - `uppercase` - (optional) Uppercase content. Default is `false`
 
-
 ### Modals
 
 ### Base Modal
 
-To use the Base Modal component, add the following markup to your Blade template.
+To use the Base Modal component, add the following markup to your Blade template. The modal can be triggered from anywhere on your page using the `NUModals.open` and `NUModals.close` methods.
 
 ```blade
 <x-kernl-modals.base
-    :modal-id="''"
+    id="unique-modal-id"
     :closeable="true|false"
     :close-on-click-outside="true|false"
     :close-on-escape-key="true|false"
 >
     {{-- Content here --}}
 </x-kernl-modals.base>
+
+<button x-data x-on:click="NUModals.open('unique-modal-id')">Open Modal</button>
+<button x-data x-on:click="NUModals.close('unique-modal-id')">Close Modal</button>
 ```
 
 #### `x-kernl-modals.base` Props
 
-- `modal-id` - Id of the modal. Must be unique throughout the app. This id can be used with `window.NUModals` methods
+- `id` - ID of the modal. Must be unique throughout the app. This ID can be used with `window.NUModals` methods
 - `closeable` - (optional) Adds close button at the top right corner. `true` by default
 - `close-on-click-outside` - (optional) Adds behavior to close when clicking outside the modal. `true` by default
 - `close-on-escape-key` - (optional) Adds behavior to close when pressing the Esc key. `true` by default

--- a/src/Components/Modals/Base.php
+++ b/src/Components/Modals/Base.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Northeastern\Blade\Components\Modals;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
+
+class Base extends Component
+{
+    public $modalId;
+
+    public $closeable;
+
+    public $closeOnClickOutside;
+
+    public $closeOnEscapeKey;
+
+    public function __construct($modalId, $closeable = true, $closeOnClickOutside = true, $closeOnEscapeKey = true)
+    {
+        $this->modalId = $modalId;
+
+        $this->closeable = $closeable;
+
+        $this->closeOnClickOutside = $closeOnClickOutside;
+
+        $this->closeOnEscapeKey = $closeOnEscapeKey;
+    }
+
+    public function render()
+    {
+        return View::make('kernl-ui::modals.base');
+    }
+}

--- a/src/Components/Modals/Base.php
+++ b/src/Components/Modals/Base.php
@@ -7,7 +7,7 @@ use Illuminate\View\Component;
 
 class Base extends Component
 {
-    public $modalId;
+    public $id;
 
     public $closeable;
 
@@ -15,9 +15,9 @@ class Base extends Component
 
     public $closeOnEscapeKey;
 
-    public function __construct($modalId, $closeable = true, $closeOnClickOutside = true, $closeOnEscapeKey = true)
+    public function __construct($id, $closeable = true, $closeOnClickOutside = true, $closeOnEscapeKey = true)
     {
-        $this->modalId = $modalId;
+        $this->id = $id;
 
         $this->closeable = $closeable;
 

--- a/src/Components/Scripts.php
+++ b/src/Components/Scripts.php
@@ -1,0 +1,13 @@
+<?php
+namespace Northeastern\Blade\Components;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
+
+class Scripts extends Component
+{
+    public function render()
+    {
+        return View::make('kernl-ui::scripts');
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -15,6 +15,8 @@ use Northeastern\Blade\Components\Carousel\Base\Slide as CarouselBaseSlide;
 use Northeastern\Blade\Components\Carousel\Split as CarouselSplit;
 use Northeastern\Blade\Components\Carousel\Split\Slide as CarouselSplitSlide;
 use Northeastern\Blade\Components\LocalHeader;
+use Northeastern\Blade\Components\Modals\Base as ModalsBase;
+use Northeastern\Blade\Components\Scripts;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -31,5 +33,8 @@ class ServiceProvider extends BaseServiceProvider
         CarouselBaseSlide::class => 'kernl-carousel.base.slide',
         CarouselSplit::class => 'kernl-carousel.split',
         CarouselSplitSlide::class => 'kernl-carousel.split.slide',
+
+        ModalsBase::class => 'kernl-modals.base',
+        Scripts::class => 'kernl-scripts',
     ];
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -19,10 +19,10 @@ use Northeastern\Blade\Components\Carousel\Split\Slide as CarouselSplitSlide;
 use Northeastern\Blade\Components\Loaders\Dark as LoadersDark;
 use Northeastern\Blade\Components\Loaders\Light as LoadersLight;
 use Northeastern\Blade\Components\LocalHeader;
-use Northeastern\Blade\Components\Tags\Outline as TagsOutline;
-use Northeastern\Blade\Components\Tags\Solid as TagsSolid;
 use Northeastern\Blade\Components\Modals\Base as ModalsBase;
 use Northeastern\Blade\Components\Scripts;
+use Northeastern\Blade\Components\Tags\Outline as TagsOutline;
+use Northeastern\Blade\Components\Tags\Solid as TagsSolid;
 
 class ServiceProvider extends BaseServiceProvider
 {

--- a/src/views/modals/base.blade.php
+++ b/src/views/modals/base.blade.php
@@ -1,0 +1,65 @@
+<div
+    x-data="{ ...modal() }"
+    class="p-4 font-sans"
+
+    x-on:keydown.window.tab="handleForwardTab"
+    x-on:keydown.window.shift.tab="handleBackwardTab"
+
+    @if($closeOnEscapeKey)
+    x-on:keydown.window.escape="handleEscape"
+    @endif
+
+    x-on:open-modal-{{ strtolower($modalId) }}.window="handleOpen"
+    x-on:close-modal-{{ strtolower($modalId) }}.window="handleClose"
+
+    x-cloak
+>
+    <div
+        role="dialog"
+        aria-labelledby="dialog-title"
+        x-ref="dialog"
+        x-show="open"
+        class="h-screen w-full fixed bottom-0 inset-x-0 z-50 sm:inset-0 sm:flex"
+    >
+        <div
+            x-show.transition.opacity.duration.300ms="open"
+            tabindex="-1"
+        >
+            <div class="absolute inset-0 bg-black bg-opacity-60"></div>
+        </div>
+
+        <div
+            x-show="open"
+            x-transition:enter="ease-out duration-300"
+            x-transition:enter-start="opacity-0 scale-90"
+            x-transition:enter-end="opacity-100 scale-100"
+            x-transition:leave="ease-in duration-200"
+            x-transition:leave-start="opacity-100 scale-100"
+            x-transition:leave-end="opacity-0 scale-90"
+            class="relative w-full h-full flex items-center justify-center p-4 transition-all"
+        >
+            <div
+                style="max-height: 85vh"
+                class="max-w-3xl w-full bg-white rounded-sm p-4 shadow-xl overflow-y-auto transition-all sm:p-8"
+                @if($closeOnClickOutside)
+                x-on:click.away="handleClose"
+                @endif
+            >
+                {{ $slot }}
+            </div>
+        </div>
+
+        @if($closeable)
+            <button
+                aria-label="Close dialog"
+                title="Close dialog"
+                type="button"
+                class="hidden absolute top-0 right-0 m-4 text-gray-200 sm:inline-block hover:text-gray-300 focus:outline-none focus:ring focus:ring-blue-500"
+                x-on:click.stop="handleClose"
+            >
+                <svg class="w-6 h-6" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+            </button>
+        @endif
+    </div>
+
+</div>

--- a/src/views/modals/base.blade.php
+++ b/src/views/modals/base.blade.php
@@ -1,7 +1,5 @@
 <div
     x-data="{ ...modal() }"
-    class="p-4 font-sans"
-
     x-on:keydown.window.tab="handleForwardTab"
     x-on:keydown.window.shift.tab="handleBackwardTab"
 
@@ -9,8 +7,8 @@
     x-on:keydown.window.escape="handleEscape"
     @endif
 
-    x-on:open-modal-{{ strtolower($modalId) }}.window="handleOpen"
-    x-on:close-modal-{{ strtolower($modalId) }}.window="handleClose"
+    x-on:open-modal-{{ strtolower($id) }}.window="handleOpen"
+    x-on:close-modal-{{ strtolower($id) }}.window="handleClose"
 
     x-cloak
 >

--- a/src/views/scripts.blade.php
+++ b/src/views/scripts.blade.php
@@ -1,0 +1,2 @@
+
+@include('kernl-ui::scripts.modals')

--- a/src/views/scripts/modals.blade.php
+++ b/src/views/scripts/modals.blade.php
@@ -1,0 +1,103 @@
+
+<script>
+    window.NUModals = {
+        open(modalId) {
+            window.dispatchEvent(new CustomEvent(`open-modal-${modalId.toLowerCase()}`))
+        },
+
+        close(modalId) {
+            window.dispatchEvent(new CustomEvent(`close-modal-${modalId.toLowerCase()}`))
+        },
+    }
+</script>
+
+<script>
+    const modal = () => {
+        return {
+            open: false,
+
+            previouslyFocusedElement: null,
+            firstFocusableElement: null,
+            lastFocusableEl: null,
+            removedTabIndexFromFirstFocusableElement: false,
+
+            toggle() {
+                this.open = !this.open;
+
+                if (this.open) {
+                    document.body.classList.add('overflow-hidden');
+                    this.focusDialog();
+                    return
+                }
+
+                document.body.classList.remove('overflow-hidden');
+
+                this.previouslyFocusedElement.focus();
+
+                if (this.removedTabIndexFromFirstFocusableElement) {
+                    this.firstFocusableElement.setAttribute('tabindex', 0);
+                }
+            },
+
+            handleOpen() {
+                if (this.open) return
+                this.toggle()
+            },
+
+            handleClose() {
+                if (!this.open) return
+                this.toggle()
+            },
+
+            focusDialog() {
+                this.previouslyFocusedElement = document.activeElement;
+
+                setTimeout(() => {
+                    const focusableElements = this.$refs.dialog.querySelectorAll('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex=\'0\']');
+
+                    if (focusableElements.length === 0) {
+                        return
+                    }
+
+                    this.firstFocusableElement = focusableElements[0];
+                    this.lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+                    this.firstFocusableElement.focus();
+
+                    if (this.firstFocusableElement.tabIndex == 0) {
+                        this.firstFocusableElement.removeAttribute('tabindex');
+                        this.removedTabIndexFromFirstFocusableElement = true;
+                    } else {
+                        this.removedTabIndexFromFirstFocusableElement = false;
+                    }
+
+                }, 200);
+            },
+
+            handleBackwardTab(e) {
+                if (! this.open) {
+                    return;
+                }
+
+                if (document.activeElement === this.firstFocusableElement) {
+                    e.preventDefault();
+                }
+            },
+
+            handleForwardTab(e) {
+                if (! this.open) {
+                    return;
+                }
+
+                if (document.activeElement === this.lastFocusableElement) {
+                    e.preventDefault();
+                    this.firstFocusableElement.focus();
+                }
+            },
+
+            handleEscape() {
+                this.handleClose()
+            },
+        }
+    }
+</script>


### PR DESCRIPTION
## Summary

This PR adds Blade components for Modals. A `Base` modal component was added to be reused among all available styles in `kernl-ui`

Modal AlpineJs scripts were extracted to a new Blade component `Scripts` that can be used to extract all other JS from components and make them reusable.

A new `window.Modals` object was added to be able to open/close modals from anywhere throughout the app. `Modals` has `close(id)` and `open(id)` methods which dispatch custom AlpineJs events that are handled by the modal component.
 
README was updated with usage instructions.

## Proposed api:
```blade
<x-kernl-modals.base
  :modal-id="'first'"
  :closeable="true"
  :close-on-click-outside="true"
  :close-on-escape-key="true"
  >
  {{-- Content here --}}
</x-kernl-modals.base>
```

## Example

![image](https://user-images.githubusercontent.com/5126648/105526634-aa887080-5cb0-11eb-9877-da46d0febfad.png)

## Type of Change

- [x] 🚀 New Feature

## Screenshot/Video

![2021-01-22 12 42 03](https://user-images.githubusercontent.com/5126648/105526371-51b8d800-5cb0-11eb-921e-4709e68f15fa.gif)
