### PR TITLE
FEATURES: Tags Blade components

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ To use the Solid Tag component, add the following markup to your Blade template.
 
 ```blade
 <x-kernl-tags.solid
-    :color="'black|white|red|gray-600|gray-300'"
+    color="black|white|red|gray-600|gray-300|blue|green|yellow"
     :pill="true|false"
     :uppercase="true|false"
 >
@@ -303,10 +303,9 @@ To use the Solid Tag component, add the following markup to your Blade template.
 
 #### `x-kernl-tags.solid` Props
 
-- `color` - Color for text/background. Default is `'black'`
+- `color` - Color for text/background. Default is `black`
 - `pill` - (optional) Rounds corners for a pill-like appearance. Default is `false`
 - `uppercase` - (optional) Uppercase content. Default is `false`
-
 
 ### Outline
 
@@ -314,7 +313,7 @@ To use the Outline Tag component, add the following markup to your Blade templat
 
 ```blade
 <x-kernl-tags.outline
-    :color="'black|white|red|gray-600|gray-300'"
+    color="black|white|red|gray-600|gray-300|blue|green|yellow"
     :pill="true|false"
     :uppercase="true|false"
 >
@@ -324,6 +323,6 @@ To use the Outline Tag component, add the following markup to your Blade templat
 
 #### `x-kernl-tags.outline` Props
 
-- `color` - Color for text/border. Default is `'black'`
+- `color` - Color for text/border. Default is `black`
 - `pill` - (optional) Rounds corners for a pill-like appearance. Default is `false`
 - `uppercase` - (optional) Uppercase content. Default is `false`

--- a/README.md
+++ b/README.md
@@ -284,3 +284,46 @@ To use the Split Carousel and Split Slide component, add the following markup to
 - `class` - Any classes you want to apply to the element around the slot. This should be used to pass in the height classes.
 
 Any additional attributes you add to the Split Slide component (`style`, etc.), will be passed through to the background element.
+
+### Tags
+
+### Solid
+
+To use the Solid Tag component, add the following markup to your Blade template.
+
+```blade
+<x-kernl-tags.solid
+    :color="'black|white|red|gray-600|gray-300'"
+    :pill="true|false"
+    :uppercase="true|false"
+>
+    {{-- Content here --}}
+</x-kernl-tags.solid>
+```
+
+#### `x-kernl-tags.solid` Props
+
+- `color` - Color for text/background. Default is `'black'`
+- `pill` - (optional) Rounds corners for a pill-like appearance. Default is `false`
+- `uppercase` - (optional) Uppercase content. Default is `false`
+
+
+### Outline
+
+To use the Outline Tag component, add the following markup to your Blade template.
+
+```blade
+<x-kernl-tags.outline
+    :color="'black|white|red|gray-600|gray-300'"
+    :pill="true|false"
+    :uppercase="true|false"
+>
+    {{-- Content here --}}
+</x-kernl-tags.outline>
+```
+
+#### `x-kernl-tags.outline` Props
+
+- `color` - Color for text/border. Default is `'black'`
+- `pill` - (optional) Rounds corners for a pill-like appearance. Default is `false`
+- `uppercase` - (optional) Uppercase content. Default is `false`

--- a/src/Components/Tags/Outline.php
+++ b/src/Components/Tags/Outline.php
@@ -1,0 +1,62 @@
+<?php
+namespace Northeastern\Blade\Components\Tags;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
+use InvalidArgumentException;
+
+class Outline extends Component
+{
+    public $color;
+
+    public $pill;
+
+    public $uppercase;
+
+    protected $colors = [
+        'black' => ['text-black', 'border-black'],
+        'white' => ['text-white', 'border-white'],
+        'gray-600' => ['text-gray-600', 'border-gray-600'],
+        'gray-300' => ['text-gray-300', 'border-gray-300'],
+        'red' => ['text-red-600', 'border-red-600'],
+    ];
+
+    public function __construct($color = 'black', $pill = false, $uppercase = false)
+    {
+        if (! array_key_exists($color, $this->colors)) {
+            throw new InvalidArgumentException('`' . $color . '` is not a supported color option.');
+        }
+
+        $this->color = $color;
+
+        $this->pill = $pill;
+
+        $this->uppercase = $uppercase;
+    }
+
+    public function compiledClasses()
+    {
+        return $this->attributes->merge([
+            'class' => collect()
+                ->merge([
+                    'inline-flex',
+                    'items-center',
+                    'p-2',
+                    'text-xs',
+                    'whitespace-nowrap',
+                    'leading-none',
+                    'border',
+                    'rounded',
+                ])
+                ->merge($this->colors[$this->color])
+                ->push($this->pill ? 'rounded-full' : '')
+                ->push($this->uppercase ? 'uppercase tracking-wide' : '')
+                ->join(' '),
+        ]);
+    }
+
+    public function render()
+    {
+        return View::make('kernl-ui::tags.outline');
+    }
+}

--- a/src/Components/Tags/Outline.php
+++ b/src/Components/Tags/Outline.php
@@ -19,6 +19,9 @@ class Outline extends Component
         'gray-600' => ['text-gray-600', 'border-gray-600'],
         'gray-300' => ['text-gray-300', 'border-gray-300'],
         'red' => ['text-red-600', 'border-red-600'],
+        'blue' => ['text-blue-700', 'border-blue-700'],
+        'green' => ['text-green-600', 'border-green-600'],
+        'yellow' => ['text-yellow-300', 'border-yellow-300'],
     ];
 
     public function __construct($color = 'black', $pill = false, $uppercase = false)

--- a/src/Components/Tags/Solid.php
+++ b/src/Components/Tags/Solid.php
@@ -1,0 +1,63 @@
+<?php
+namespace Northeastern\Blade\Components\Tags;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
+use InvalidArgumentException;
+
+class Solid extends Component
+{
+    public $color;
+
+    public $pill;
+
+    public $uppercase;
+
+    protected $colors = [
+        'black' => ['text-white', 'bg-black'],
+        'white' => ['text-gray-900', 'bg-white'],
+        'gray-600' => ['text-white', 'bg-gray-600'],
+        'gray-300' => ['text-gray-900', 'bg-gray-300'],
+        'red' => ['text-white', 'bg-red-600'],
+    ];
+
+    public function __construct($color = 'black', $pill = false, $uppercase = false)
+    {
+        if (! array_key_exists($color, $this->colors)) {
+            throw new InvalidArgumentException('`' . $color . '` is not a supported color option.');
+        }
+
+        $this->color = $color;
+
+        $this->pill = $pill;
+
+        $this->uppercase = $uppercase;
+    }
+
+    public function compiledClasses()
+    {
+        return $this->attributes->merge([
+            'class' => collect()
+                ->merge([
+                    'inline-flex',
+                    'items-center',
+                    'p-2',
+                    'text-xs',
+                    'whitespace-nowrap',
+                    'leading-none',
+                    'border',
+                    'border-transparent',
+                    'rounded',
+                ])
+                ->merge($this->colors[$this->color])
+                ->push($this->pill ? 'rounded-full' : '')
+                ->push($this->uppercase ? 'uppercase tracking-wide' : '')
+                ->join(' '),
+        ]);
+    }
+
+    public function render()
+    {
+        return View::make('kernl-ui::tags.solid');
+    }
+}

--- a/src/Components/Tags/Solid.php
+++ b/src/Components/Tags/Solid.php
@@ -19,6 +19,9 @@ class Solid extends Component
         'gray-600' => ['text-white', 'bg-gray-600'],
         'gray-300' => ['text-gray-900', 'bg-gray-300'],
         'red' => ['text-white', 'bg-red-600'],
+        'blue' => ['text-white', 'bg-blue-700'],
+        'green' => ['text-white', 'bg-green-600'],
+        'yellow' => ['text-black', 'bg-yellow-300'],
     ];
 
     public function __construct($color = 'black', $pill = false, $uppercase = false)

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -15,8 +15,8 @@ use Northeastern\Blade\Components\Carousel\Base\Slide as CarouselBaseSlide;
 use Northeastern\Blade\Components\Carousel\Split as CarouselSplit;
 use Northeastern\Blade\Components\Carousel\Split\Slide as CarouselSplitSlide;
 use Northeastern\Blade\Components\LocalHeader;
-use Northeastern\Blade\Components\Tags\Solid as TagsSolid;
 use Northeastern\Blade\Components\Tags\Outline as TagsOutline;
+use Northeastern\Blade\Components\Tags\Solid as TagsSolid;
 
 class ServiceProvider extends BaseServiceProvider
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -15,6 +15,8 @@ use Northeastern\Blade\Components\Carousel\Base\Slide as CarouselBaseSlide;
 use Northeastern\Blade\Components\Carousel\Split as CarouselSplit;
 use Northeastern\Blade\Components\Carousel\Split\Slide as CarouselSplitSlide;
 use Northeastern\Blade\Components\LocalHeader;
+use Northeastern\Blade\Components\Tags\Solid as TagsSolid;
+use Northeastern\Blade\Components\Tags\Outline as TagsOutline;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -31,5 +33,8 @@ class ServiceProvider extends BaseServiceProvider
         CarouselBaseSlide::class => 'kernl-carousel.base.slide',
         CarouselSplit::class => 'kernl-carousel.split',
         CarouselSplitSlide::class => 'kernl-carousel.split.slide',
+
+        TagsSolid::class => 'kernl-tags.solid',
+        TagsOutline::class => 'kernl-tags.outline',
     ];
 }

--- a/src/views/tags/outline.blade.php
+++ b/src/views/tags/outline.blade.php
@@ -1,0 +1,3 @@
+<span {{ $compiledClasses() }}>
+    {{ $slot }}
+</span>

--- a/src/views/tags/solid.blade.php
+++ b/src/views/tags/solid.blade.php
@@ -1,0 +1,3 @@
+<span {{ $compiledClasses() }}>
+    {{ $slot }}
+</span>


### PR DESCRIPTION
## Summary

This PR adds Blade components for all Tags styles:
- Solid
- Outline

For each style, a Component class was added.

README was updated with usage instructions.

## Proposed api:
```blade
<x-kernl-tags.solid
    :color="'black|white|red|gray-600|gray-300'"
    :pill="true|false"
    :uppercase="true|false"
>
    {{-- Content here --}}
</x-kernl-tags.solid>

<x-kernl-tags.outline
    :color="'black|white|red|gray-600|gray-300'"
    :pill="true|false"
    :uppercase="true|false"
>
    {{-- Content here --}}
</x-kernl-tags.outline>
```

## Example

![image](https://user-images.githubusercontent.com/5126648/105541742-35279a80-5cc6-11eb-9821-e46d4c05c89b.png)

## Type of Change

- [x] 🚀 New Feature

## Screenshot/Video

![image](https://user-images.githubusercontent.com/5126648/105541752-3953b800-5cc6-11eb-9d8f-49574e7aa82c.png)
