### PR TITLE
FEATURES: Added "aqua" color for button styles

### DIFF
--- a/src/Components/Button/Outline.php
+++ b/src/Components/Button/Outline.php
@@ -24,6 +24,7 @@ class Outline extends Component
         'red' => 'text-red-600 border-red-600 hover:text-white hover:bg-red-600',
         'blue' => 'text-blue-700 border-blue-700 hover:text-white hover:bg-blue-700',
         'green' => 'text-green-600 border-green-600 hover:text-white hover:bg-green-600',
+        'aqua' => 'text-aqua-500 border-aqua-500 hover:text-white hover:bg-aqua-500',
     ];
 
     public function __construct($color = 'black', $href = '', $size = '')

--- a/src/Components/Button/Solid.php
+++ b/src/Components/Button/Solid.php
@@ -24,6 +24,7 @@ class Solid extends Component
         'red' => 'text-white bg-red-600 hover:bg-red-700',
         'blue' => 'text-white bg-blue-700 hover:bg-blue-800',
         'green' => 'text-white bg-green-600 hover:bg-green-700',
+        'aqua' => 'text-white bg-aqua-500 hover:bg-aqua-600',
     ];
 
     public function __construct($color = 'black', $href = '', $size = '')


### PR DESCRIPTION
## Summary

This PR adds support for "aqua" color in button components. Color `aqua-500` is used.

## Type of Change

- [x] 🚀 New Feature

## Screenshot/Video

![image](https://user-images.githubusercontent.com/5126648/106166933-ac43af80-615a-11eb-95ac-cb7de8df4016.png)

