### PR TITLE
FEATURES: Interior Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,3 +566,39 @@ Any additional classes or attributes you put on the `item` component will be pas
 - `title` - Title of the tab contents
 
 Any additional classes or attributes you put on the `item` component will be passed through.
+
+
+### Interior Navigation
+
+```blade
+<x-kernl-interior-navigation.base
+    title="About"
+    :links="[
+        [
+            'text' => 'Our Staff',
+            'href' => '#',
+        ],
+        [
+            'text' => 'Job Opportunities',
+            'expandable' => true,
+            'expanded' => true,
+            'children' => [
+                ['text' => 'Part Time', 'href' => '#'],
+                ['text' => 'Full Time', 'href' => '#'],
+            ],
+        ],
+    ]"
+/>
+```
+
+#### `x-kernl-interior-navigation.base` Props
+
+- `title` - Title for navigation
+- `links` - Array of navigation items. Supports child navigation via `children` key. Navigation items can have the following attributes:
+  - `text` - Text for navigation item
+  - `active` - Sets navigation item as active. Default is `false`
+  - `children` - Child navigation for navigation items.
+  - `expandable` - Sets whether the child navigation can be expandable/collapsible. Applies when `children` is used. Default is `false`.
+  - `expanded` - Sets whether the child navigation is expanded or not by default. Applies when `expandable` is used. Default is `false`.
+
+Any additional classes or attributes you put on the `base` component will be passed through the root div component.

--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ Any additional classes or attributes you put on the `item` component will be pas
 ```blade
 <x-kernl-interior-navigation.base
     title="About"
+    title-url="#"
     :links="[
         [
             'text' => 'Our Staff',
@@ -594,8 +595,10 @@ Any additional classes or attributes you put on the `item` component will be pas
 #### `x-kernl-interior-navigation.base` Props
 
 - `title` - Title for navigation
+- `title-url` - (optional) Url for navigation 
 - `links` - Array of navigation items. Supports child navigation via `children` key. Navigation items can have the following attributes:
   - `text` - Text for navigation item
+  - `href` - Url for navigation item
   - `active` - Sets navigation item as active. Default is `false`
   - `children` - Child navigation for navigation items.
   - `expandable` - Sets whether the child navigation can be expandable/collapsible. Applies when `children` is used. Default is `false`.

--- a/README.md
+++ b/README.md
@@ -653,14 +653,14 @@ Any additional classes or attributes you put on the component will be passed thr
 #### `x-kernl-interior-navigation.base` Props
 
 - `title` - Title for navigation
-- `title-url` - (optional) Url for navigation
+- `title-url` - (optional) URL for navigation
 - `links` - Array of navigation items. Supports child navigation via `children` key. Navigation items can have the following attributes:
-  - `text` - Text for navigation item
-  - `href` - Url for navigation item
-  - `active` - Sets navigation item as active. Default is `false`
-  - `children` - Child navigation for navigation items.
-  - `expandable` - Sets whether the child navigation can be expandable/collapsible. Applies when `children` is used. Default is `false`.
-  - `expanded` - Sets whether the child navigation is expanded or not by default. Applies when `expandable` is used. Default is `false`.
+  - `text` - Text for the navigation item
+  - `href` - URL for the navigation item
+  - `active` - Sets the navigation item as active. Default is `false`
+  - `children` - Child navigation for navigation items
+  - `expandable` - Sets whether the child navigation can be expanded/collapsed. Applies when `children` is used. Default is `false`
+  - `expanded` - Sets whether the child navigation is expanded or not by default. Applies when `expandable` is used. Default is `false`
 
 Any additional classes or attributes you put on the `base` component will be passed through the root div component.
 

--- a/src/Components/InteriorNavigation/Base.php
+++ b/src/Components/InteriorNavigation/Base.php
@@ -8,11 +8,14 @@ class Base extends Component
 {
     public $title;
 
+    public $titleUrl;
+
     public $links;
 
-    public function __construct($title = null, $links = [])
+    public function __construct($title, $titleUrl = null, $links = [])
     {
         $this->title = $title;
+        $this->titleUrl = $titleUrl;
         $this->links = $links;
     }
 

--- a/src/Components/InteriorNavigation/Base.php
+++ b/src/Components/InteriorNavigation/Base.php
@@ -1,0 +1,23 @@
+<?php
+namespace Northeastern\Blade\Components\InteriorNavigation;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
+
+class Base extends Component
+{
+    public $title;
+
+    public $links;
+
+    public function __construct($title = null, $links = [])
+    {
+        $this->title = $title;
+        $this->links = $links;
+    }
+
+    public function render()
+    {
+        return View::make('kernl-ui::interior-navigation.base');
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,6 +17,7 @@ use Northeastern\Blade\Components\Carousel\Base\Slide as CarouselBaseSlide;
 use Northeastern\Blade\Components\Carousel\Split as CarouselSplit;
 use Northeastern\Blade\Components\Carousel\Split\Slide as CarouselSplitSlide;
 use Northeastern\Blade\Components\Footers\Local as FooterLocal;
+use Northeastern\Blade\Components\InteriorNavigation\Base as InteriorNavigationBase;
 use Northeastern\Blade\Components\Loaders\Dark as LoadersDark;
 use Northeastern\Blade\Components\Loaders\Light as LoadersLight;
 use Northeastern\Blade\Components\LocalHeader;
@@ -58,5 +59,6 @@ class ServiceProvider extends BaseServiceProvider
         TabsBordered\Item::class => 'kernl-tabs.bordered.item',
         TabsDetached::class => 'kernl-tabs.detached',
         TabsDetached\Item::class => 'kernl-tabs.detached.item',
+        InteriorNavigationBase::class => 'kernl-interior-navigation.base',
     ];
 }

--- a/src/views/includes/interior-navigation/base/link-with-children.blade.php
+++ b/src/views/includes/interior-navigation/base/link-with-children.blade.php
@@ -1,0 +1,57 @@
+<div
+    @if(data_get($link, 'expandable', false))
+        x-data="{
+            expanded: {{ data_get($link, 'expanded', false) ? 'true' : 'false' }}
+        }"
+    @endif
+>
+    <button
+        class="
+            w-full flex items-center justify-between text-left
+            @if(data_get($link, 'active', false))
+                px-2 border-l-2 transition-colors text-gray-900 font-bold border-red-600
+            @else
+                px-2 border-l-2 transition-colors border-transparent hover:text-gray-900
+            @endif
+        "
+        @if(data_get($link, 'expandable', false))
+            x-on:click="expanded = ! expanded"
+        @endif
+    >
+        <span>
+            {{ data_get($link, 'text', 'No text') }}
+        </span>
+        @if(data_get($link, 'expandable', false))
+            <svg
+                x-bind:class="{ 'rotate-180': expanded }"
+                class="ml-3 w-5 h-5 transform transition-transform rotate-180"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+            >
+                <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+        @endif
+    </button>
+    <ul
+        @if(data_get($link, 'expandable', false))
+            x-show="expanded"
+            x-cloak
+        @endif
+        class="py-2 text-sm space-y-2"
+    >
+        @foreach(data_get($link, 'children', []) as $child)
+            <li>
+                <a
+                    href="{{ data_get($child, 'href', '#') }}"
+                    class="px-4 transition-colors hover:text-gray-900"
+                >
+                    {{ data_get($child, 'text', 'No text') }}
+                </a>
+            </li>
+        @endforeach
+    </ul>
+</div>

--- a/src/views/includes/interior-navigation/base/link-with-children.blade.php
+++ b/src/views/includes/interior-navigation/base/link-with-children.blade.php
@@ -5,25 +5,22 @@
         }"
     @endif
 >
-    <button
-        class="
-            w-full flex items-center justify-between text-left
-            @if(data_get($link, 'active', false))
-                px-2 border-l-2 transition-colors text-gray-900 font-bold border-red-600
-            @else
-                px-2 border-l-2 transition-colors border-transparent hover:text-gray-900
-            @endif
-        "
-        @if(data_get($link, 'expandable', false))
+    @if(data_get($link, 'expandable', false))
+        <button
+            class="
+                w-full flex items-center justify-between text-left
+                @if(data_get($link, 'active', false))
+                    px-2 border-l-2 transition-colors text-gray-900 font-bold border-red-600
+                @else
+                    px-2 border-l-2 transition-colors border-transparent hover:text-gray-900
+                @endif
+            "
             x-on:click="expanded = ! expanded"
-        @endif
-    >
-        <span>
-            {{ $link['text'] }}
-        </span>
-        @if(data_get($link, 'expandable', false))
+        >
+            <span>
+                {{ $link['text'] }}
+            </span>
             <svg
-                x-bind:class="{ 'rotate-180': expanded }"
                 class="ml-3 w-5 h-5 transform transition-transform rotate-180"
                 viewBox="0 0 24 24"
                 fill="none"
@@ -31,11 +28,28 @@
                 stroke-width="2"
                 stroke-linecap="round"
                 stroke-linejoin="round"
+                x-bind:class="{ 'rotate-180': expanded }"
+                x-cloak
             >
                 <polyline points="6 9 12 15 18 9"></polyline>
             </svg>
-        @endif
-    </button>
+        </button>
+    @else
+        <a
+            href="{{ data_get($link, 'href', '#') }}"
+            class="
+                w-full flex items-center justify-between text-left
+                @if(data_get($link, 'active', false))
+                    px-2 border-l-2 transition-colors text-gray-900 font-bold border-red-600
+                @else
+                    px-2 border-l-2 transition-colors border-transparent hover:text-gray-900
+                @endif
+            "
+        >
+            {{ $link['text'] }}
+        </a>
+    @endif
+
     <ul
         @if(data_get($link, 'expandable', false))
             x-show="expanded"

--- a/src/views/includes/interior-navigation/base/link-with-children.blade.php
+++ b/src/views/includes/interior-navigation/base/link-with-children.blade.php
@@ -19,7 +19,7 @@
         @endif
     >
         <span>
-            {{ data_get($link, 'text', 'No text') }}
+            {{ $link['text'] }}
         </span>
         @if(data_get($link, 'expandable', false))
             <svg

--- a/src/views/includes/interior-navigation/base/link.blade.php
+++ b/src/views/includes/interior-navigation/base/link.blade.php
@@ -6,5 +6,5 @@
         class="px-2 border-l-2 transition-colors border-transparent hover:text-gray-900"
     @endif
 >
-    {{ data_get($link, 'text', 'No text') }}
+    {{ $link['text'] }}
 </a>

--- a/src/views/includes/interior-navigation/base/link.blade.php
+++ b/src/views/includes/interior-navigation/base/link.blade.php
@@ -1,0 +1,10 @@
+<a
+    href="{{ data_get($link, 'href', '#') }}"
+    @if(data_get($link, 'active', false))
+        class="px-2 border-l-2 transition-colors text-gray-900 font-bold border-red-600"
+    @else
+        class="px-2 border-l-2 transition-colors border-transparent hover:text-gray-900"
+    @endif
+>
+    {{ data_get($link, 'text', 'No text') }}
+</a>

--- a/src/views/interior-navigation/base.blade.php
+++ b/src/views/interior-navigation/base.blade.php
@@ -67,56 +67,9 @@
         </a>
         @foreach($links as $link)
             @if(count(data_get($link, 'children', [])) > 0)
-                <div
-                    x-data="{ expanded: false }"
-                >
-                    <button
-                        class="w-full flex items-center justify-between px-2 text-left border-l-2 transition-colors border-transparent hover:text-gray-900"
-                        x-on:click="expanded = ! expanded"
-                    >
-                    <span>
-                        {{ data_get($link, 'text', 'No text') }}
-                    </span>
-                        <svg
-                            x-bind:class="{ 'rotate-180': expanded }"
-                            class="ml-3 w-5 h-5 transform transition-transform rotate-180"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                        >
-                            <polyline points="6 9 12 15 18 9"></polyline>
-                        </svg>
-                    </button>
-                    <ul
-                        x-show="expanded"
-                        class="py-2 text-sm space-y-2"
-                    >
-                        @foreach(data_get($link, 'children', []) as $child)
-                            <li>
-                                <a
-                                    href="{{ data_get($child, 'href', '#') }}"
-                                    class="px-4 transition-colors hover:text-gray-900"
-                                >
-                                    {{ data_get($child, 'text', 'No text') }}
-                                </a>
-                            </li>
-                        @endforeach
-                    </ul>
-                </div>
+                @include('kernl-ui::includes.interior-navigation.base.link-with-children', ['link' => $link])
             @else
-                <a
-                    href="{{ data_get($link, 'href', '#') }}"
-                    @if(data_get($link, 'active', false))
-                        class="px-2 border-l-2 transition-colors text-gray-900 font-bold border-red-600"
-                    @else
-                        class="mt-3 px-2 border-l-2 transition-colors border-transparent hover:text-gray-900"
-                    @endif
-                >
-                    {{ data_get($link, 'text', 'No text') }}
-                </a>
+                @include('kernl-ui::includes.interior-navigation.base.link', ['link' => $link])
             @endif
         @endforeach
     </nav>

--- a/src/views/interior-navigation/base.blade.php
+++ b/src/views/interior-navigation/base.blade.php
@@ -1,63 +1,100 @@
-<div x-data="{
-                    navIsOpen: true,
-                    init() {
-                    console.log('helop')
-                        document.body.classList.add('overflow-x-hidden');
-                        this.$watch('navIsOpen', (val) => document.body.classList[val ? 'add' : 'remove']('overflow-y-hidden'));
-                    }
-                }" x-init="init()"
-     class="px-4 md:w-1/3 lg:w-1/5 lg:px-4" @keydown.window.escape="navIsOpen = false">
-    <button class="btn text-gray-900 uppercase bg-gray-200 md:hidden hover:bg-gray-300" @click="navIsOpen = true">
-        About
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu ml-2 w-4 h-4"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+{{-- Mobile --}}
+<div
+    x-data="{
+        navIsOpen: false,
+        init() {
+            document.body.classList.add('overflow-x-hidden');
+            this.$watch('navIsOpen', (val) => document.body.classList[val ? 'add' : 'remove']('overflow-y-hidden'));
+        }
+    }"
+    x-init="init()"
+    x-on:keydown.window.escape="navIsOpen = false"
+    {{ $attributes }}
+>
+    <button
+        class="btn text-gray-900 uppercase bg-gray-200 md:hidden hover:bg-gray-300"
+        x-on:click="navIsOpen = true"
+    >
+        {{ $title ?? 'No title' }}
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="feather feather-menu ml-2 w-4 h-4">
+            <line x1="3" y1="12" x2="21" y2="12"></line>
+            <line x1="3" y1="6" x2="21" y2="6"></line>
+            <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
     </button>
-    <div class="fixed inset-0 w-full h-full bg-black bg-opacity-80 md:hidden" x-show="navIsOpen" x-transition:enter="transition-opacity ease-out duration-300" x-transition:enter-start="opacity-0" x-transition:leave="transition-opacity ease-in duration-300" x-transition:leave-end="opacity-0" style="display: none;"></div>
-    <nav aria-label="mobile category navigation" x-show="navIsOpen" class="fixed inset-y-0 right-0 max-w-sm w-full py-12 px-6 text-gray-600 bg-white overflow-y-auto shadow md:hidden" x-transition:enter="transition-transform ease-out duration-300" x-transition:enter-start="transform translate-x-full" x-transition:leave="transition-transform ease-in duration-300" x-transition:leave-end="transform translate-x-full" @click.away="navIsOpen = false" style="display: none;">
-        <div class="flex flex-col">
+    {{-- Overlay --}}
+    <div
+        class="fixed inset-0 w-full h-full bg-black bg-opacity-80 md:hidden"
+        x-show="navIsOpen"
+        x-transition:enter="transition-opacity ease-out duration-300"
+        x-transition:enter-start="opacity-0"
+        x-transition:leave="transition-opacity ease-in duration-300"
+        x-transition:leave-end="opacity-0"
+        style="display: none;"
+    ></div>
+
+    <nav
+        aria-label="mobile category navigation"
+        class="fixed inset-y-0 right-0 max-w-sm w-full py-12 px-6 text-gray-600 bg-white overflow-y-auto shadow md:hidden"
+        style="display: none;"
+
+        x-show="navIsOpen"
+        x-on:click.away="navIsOpen = false"
+
+        x-transition:enter="transition-transform ease-out duration-300"
+        x-transition:enter-start="transform translate-x-full"
+        x-transition:leave="transition-transform ease-in duration-300"
+        x-transition:leave-end="transform translate-x-full"
+    >
+        <div class="flex flex-col space-y-3">
             <div class="w-full flex items-center justify-between">
                 <a href="#" class="px-2 uppercase tracking-wide text-gray-900 border-l-2 border-transparent">
-                    About
+                    {{ $title ?? 'No title' }}
                 </a>
                 <button class="text-gray-500 md:hidden transition-colors hover:text-gray-600 focus:outline-none focus:ring focus:ring-blue-500" @click="navIsOpen = false">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x w-6 h-6"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
-                </button>
-            </div>
-            <a class="mt-3 px-2 border-l-2 transition-colors border-transparent hover:text-gray-900" href="#">
-                Our Staff
-            </a>
-            <div x-data="{ expanded: false }" class="mt-3">
-                <button class="w-full flex items-center justify-between px-2 text-left border-l-2 transition-colors border-transparent hover:text-gray-900" @click="expanded = ! expanded">
-                    <span>Job Opportunities</span>
-                    <svg :class="{ 'rotate-180': expanded }" class="ml-3 w-4 h-4 transform transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <polyline points="6 9 12 15 18 9"></polyline>
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="feather feather-x w-6 h-6"
+                    >
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
                     </svg>
                 </button>
-                <ul x-show="expanded" class="py-2 text-sm space-y-2" style="display: none;">
-                    <li>
-                        <a href="#" class="px-4 transition-colors hover:text-gray-900">Full-time positions</a>
-                    </li>
-                    <li>
-                        <a href="#" class="px-4 transition-colors hover:text-gray-900">Part-time positions</a>
-                    </li>
-                </ul>
             </div>
-            <a class="mt-3 px-2 border-l-2 transition-colors border-transparent hover:text-gray-900" href="#">
-                Our Community Partners
-            </a>
-            <!-- Active URL state -->
-            <a class="mt-3 px-2 border-l-2 transition-colors text-gray-900 font-bold border-red-600" href="#">
-                Awards, Grants, and Recognitions
-            </a>
-            <a class="mt-3 px-2 border-l-2 transition-colors border-transparent hover:text-gray-900" href="#">
-                Donations and Sponsorships
-            </a>
-            <a class="mt-3 px-2 border-l-2 transition-colors border-transparent hover:text-gray-900" href="#">
-                Contact Us
-            </a>
+
+            @foreach($links as $link)
+                @if(count(data_get($link, 'children', [])) > 0)
+                    @include('kernl-ui::includes.interior-navigation.base.link-with-children', ['link' => $link])
+                @else
+                    @include('kernl-ui::includes.interior-navigation.base.link', ['link' => $link])
+                @endif
+            @endforeach
         </div>
     </nav>
+</div>
 
-    {{-- Desktop --}}
+{{-- Desktop --}}
+<div
+    {{ $attributes->merge(['class' => 'px-4 md:w-1/3 lg:w-1/5']) }}
+>
     <nav
         aria-label="desktop category navigation"
         class="hidden sticky top-0 py-8 text-gray-600 md:flex flex-col space-y-3"

--- a/src/views/interior-navigation/base.blade.php
+++ b/src/views/interior-navigation/base.blade.php
@@ -1,0 +1,123 @@
+<div x-data="{
+                    navIsOpen: true,
+                    init() {
+                    console.log('helop')
+                        document.body.classList.add('overflow-x-hidden');
+                        this.$watch('navIsOpen', (val) => document.body.classList[val ? 'add' : 'remove']('overflow-y-hidden'));
+                    }
+                }" x-init="init()"
+     class="px-4 md:w-1/3 lg:w-1/5 lg:px-4" @keydown.window.escape="navIsOpen = false">
+    <button class="btn text-gray-900 uppercase bg-gray-200 md:hidden hover:bg-gray-300" @click="navIsOpen = true">
+        About
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-menu ml-2 w-4 h-4"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+    </button>
+    <div class="fixed inset-0 w-full h-full bg-black bg-opacity-80 md:hidden" x-show="navIsOpen" x-transition:enter="transition-opacity ease-out duration-300" x-transition:enter-start="opacity-0" x-transition:leave="transition-opacity ease-in duration-300" x-transition:leave-end="opacity-0" style="display: none;"></div>
+    <nav aria-label="mobile category navigation" x-show="navIsOpen" class="fixed inset-y-0 right-0 max-w-sm w-full py-12 px-6 text-gray-600 bg-white overflow-y-auto shadow md:hidden" x-transition:enter="transition-transform ease-out duration-300" x-transition:enter-start="transform translate-x-full" x-transition:leave="transition-transform ease-in duration-300" x-transition:leave-end="transform translate-x-full" @click.away="navIsOpen = false" style="display: none;">
+        <div class="flex flex-col">
+            <div class="w-full flex items-center justify-between">
+                <a href="#" class="px-2 uppercase tracking-wide text-gray-900 border-l-2 border-transparent">
+                    About
+                </a>
+                <button class="text-gray-500 md:hidden transition-colors hover:text-gray-600 focus:outline-none focus:ring focus:ring-blue-500" @click="navIsOpen = false">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x w-6 h-6"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                </button>
+            </div>
+            <a class="mt-3 px-2 border-l-2 transition-colors border-transparent hover:text-gray-900" href="#">
+                Our Staff
+            </a>
+            <div x-data="{ expanded: false }" class="mt-3">
+                <button class="w-full flex items-center justify-between px-2 text-left border-l-2 transition-colors border-transparent hover:text-gray-900" @click="expanded = ! expanded">
+                    <span>Job Opportunities</span>
+                    <svg :class="{ 'rotate-180': expanded }" class="ml-3 w-4 h-4 transform transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="6 9 12 15 18 9"></polyline>
+                    </svg>
+                </button>
+                <ul x-show="expanded" class="py-2 text-sm space-y-2" style="display: none;">
+                    <li>
+                        <a href="#" class="px-4 transition-colors hover:text-gray-900">Full-time positions</a>
+                    </li>
+                    <li>
+                        <a href="#" class="px-4 transition-colors hover:text-gray-900">Part-time positions</a>
+                    </li>
+                </ul>
+            </div>
+            <a class="mt-3 px-2 border-l-2 transition-colors border-transparent hover:text-gray-900" href="#">
+                Our Community Partners
+            </a>
+            <!-- Active URL state -->
+            <a class="mt-3 px-2 border-l-2 transition-colors text-gray-900 font-bold border-red-600" href="#">
+                Awards, Grants, and Recognitions
+            </a>
+            <a class="mt-3 px-2 border-l-2 transition-colors border-transparent hover:text-gray-900" href="#">
+                Donations and Sponsorships
+            </a>
+            <a class="mt-3 px-2 border-l-2 transition-colors border-transparent hover:text-gray-900" href="#">
+                Contact Us
+            </a>
+        </div>
+    </nav>
+
+    {{-- Desktop --}}
+    <nav
+        aria-label="desktop category navigation"
+        class="hidden sticky top-0 py-8 text-gray-600 md:flex flex-col space-y-3"
+    >
+        <a href="#" class="px-2 uppercase tracking-wide text-gray-900 border-l-2 border-transparent">
+            {{ $title ?? 'No title' }}
+        </a>
+        @foreach($links as $link)
+            @if(count(data_get($link, 'children', [])) > 0)
+                <div
+                    x-data="{ expanded: false }"
+                >
+                    <button
+                        class="w-full flex items-center justify-between px-2 text-left border-l-2 transition-colors border-transparent hover:text-gray-900"
+                        x-on:click="expanded = ! expanded"
+                    >
+                    <span>
+                        {{ data_get($link, 'text', 'No text') }}
+                    </span>
+                        <svg
+                            x-bind:class="{ 'rotate-180': expanded }"
+                            class="ml-3 w-5 h-5 transform transition-transform rotate-180"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                        >
+                            <polyline points="6 9 12 15 18 9"></polyline>
+                        </svg>
+                    </button>
+                    <ul
+                        x-show="expanded"
+                        class="py-2 text-sm space-y-2"
+                    >
+                        @foreach(data_get($link, 'children', []) as $child)
+                            <li>
+                                <a
+                                    href="{{ data_get($child, 'href', '#') }}"
+                                    class="px-4 transition-colors hover:text-gray-900"
+                                >
+                                    {{ data_get($child, 'text', 'No text') }}
+                                </a>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            @else
+                <a
+                    href="{{ data_get($link, 'href', '#') }}"
+                    @if(data_get($link, 'active', false))
+                        class="px-2 border-l-2 transition-colors text-gray-900 font-bold border-red-600"
+                    @else
+                        class="mt-3 px-2 border-l-2 transition-colors border-transparent hover:text-gray-900"
+                    @endif
+                >
+                    {{ data_get($link, 'text', 'No text') }}
+                </a>
+            @endif
+        @endforeach
+    </nav>
+</div>

--- a/src/views/interior-navigation/base.blade.php
+++ b/src/views/interior-navigation/base.blade.php
@@ -15,7 +15,7 @@
         class="btn text-gray-900 uppercase bg-gray-200 md:hidden hover:bg-gray-300"
         x-on:click="navIsOpen = true"
     >
-        {{ $title ?? 'No title' }}
+        {{ $title }}
         <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"
@@ -59,7 +59,7 @@
         <div class="flex flex-col space-y-3">
             <div class="w-full flex items-center justify-between">
                 <a href="#" class="px-2 uppercase tracking-wide text-gray-900 border-l-2 border-transparent">
-                    {{ $title ?? 'No title' }}
+                    {{ $title }}
                 </a>
                 <button class="text-gray-500 md:hidden transition-colors hover:text-gray-600 focus:outline-none focus:ring focus:ring-blue-500" @click="navIsOpen = false">
                     <svg

--- a/src/views/interior-navigation/base.blade.php
+++ b/src/views/interior-navigation/base.blade.php
@@ -99,8 +99,8 @@
         aria-label="desktop {{ strtolower($title) }} navigation"
         class="hidden sticky top-0 py-8 text-gray-600 md:flex flex-col space-y-3"
     >
-        <a href="#" class="px-2 uppercase tracking-wide text-gray-900 border-l-2 border-transparent">
-            {{ $title ?? 'No title' }}
+        <a href="{{ $titleUrl ?? '#' }}" class="px-2 uppercase tracking-wide text-gray-900 border-l-2 border-transparent">
+            {{ $title }}
         </a>
         @foreach($links as $link)
             @if(count(data_get($link, 'children', [])) > 0)

--- a/src/views/interior-navigation/base.blade.php
+++ b/src/views/interior-navigation/base.blade.php
@@ -44,7 +44,7 @@
     ></div>
 
     <nav
-        aria-label="mobile category navigation"
+        aria-label="mobile {{ strtolower($title) }} navigation"
         class="fixed inset-y-0 right-0 max-w-sm w-full py-12 px-6 text-gray-600 bg-white overflow-y-auto shadow md:hidden"
         style="display: none;"
 
@@ -96,7 +96,7 @@
     {{ $attributes->merge(['class' => 'px-4 md:w-1/3 lg:w-1/5']) }}
 >
     <nav
-        aria-label="desktop category navigation"
+        aria-label="desktop {{ strtolower($title) }} navigation"
         class="hidden sticky top-0 py-8 text-gray-600 md:flex flex-col space-y-3"
     >
         <a href="#" class="px-2 uppercase tracking-wide text-gray-900 border-l-2 border-transparent">


### PR DESCRIPTION
## Summary

This PR adds a Blade component for Interior Navigation. Component supports both mobile and desktop. Allows also to specify children navigation and expandable/collapsible behavior.

## Proposed api:
```blade
<x-kernl-interior-navigation.base
    title="About"
    :links="[
        [
            'text' => 'Our Staff',
            'href' => '#',
        ],
        [
            'text' => 'Job Opportunities',
            'expandable' => true,
            'expanded' => true,
            'children' => [
                ['text' => 'Part Time', 'href' => '#'],
                ['text' => 'Full Time', 'href' => '#'],
            ],
        ],
    ]"
/>
```

## Example

![image](https://user-images.githubusercontent.com/5126648/109428756-7ba79d80-79c6-11eb-816f-22b4836bc966.png)

![image](https://user-images.githubusercontent.com/5126648/109428758-806c5180-79c6-11eb-8daf-46a2b3f58d18.png)

![image](https://user-images.githubusercontent.com/5126648/109428761-85c99c00-79c6-11eb-986a-1cb25d1cbde3.png)

## Type of Change

- [x] 🚀 New Feature

## Screenshot/Video

![2021-02-28 13 00 26](https://user-images.githubusercontent.com/5126648/109428767-8d894080-79c6-11eb-9ee4-7ee90f9aa9cf.gif)

