### PR TITLE
FEATURES: Base Paginator Blade component

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,3 +968,28 @@ Keyed array must have keys for `input-changed` event and `filter` with the desir
 Any additional classes or attributes you put on the component will be passed through.
 
 > Note: The `@tailwindcss/forms` plugin is required for the this component to work correctly. Please see [documentation](https://northeastern.netlify.app/docs/plugins/#tailwind-forms)
+
+
+### Paginators
+
+```blade
+<x-kernl-paginators.base
+    :number-of-pages="available pages"
+    :current-page="current page"
+    mode="php|js"
+    pagination-url="url for pagination"
+    query-param-name="name of page query param"
+    :appends="extra values for pagination"
+    emits="name of the event to emit"
+/>
+```
+
+#### `x-kernl-paginators.base` Props
+
+- `:number-of-pages` - Number of available pages for pagination.
+- `:current-page` - Initial selected page.
+- `mode` - (optional) `php` or `js`. Defaults to `php`.
+- `pagination-url` - (`php` mode) Url used for pagination.
+- `query-param-name` - (optional - `php` mode) Name of the page query param. Defaults to `page`.
+- `:appends` - (optional - `php` mode) Extra keyed array values to attach to pagination url
+- `emits` - (optional - `js` mode) Name of event dispatched when switching pages

--- a/README.md
+++ b/README.md
@@ -969,7 +969,6 @@ Any additional classes or attributes you put on the component will be passed thr
 
 > Note: The `@tailwindcss/forms` plugin is required for the this component to work correctly. Please see [documentation](https://northeastern.netlify.app/docs/plugins/#tailwind-forms)
 
-
 ### Paginators
 
 ```blade
@@ -989,7 +988,9 @@ Any additional classes or attributes you put on the component will be passed thr
 - `:number-of-pages` - Number of available pages for pagination.
 - `:current-page` - Initial selected page.
 - `mode` - (optional) `php` or `js`. Defaults to `php`.
-- `pagination-url` - (`php` mode) Url used for pagination.
-- `query-param-name` - (optional - `php` mode) Name of the page query param. Defaults to `page`.
-- `:appends` - (optional - `php` mode) Extra keyed array values to attach to pagination url
-- `emits` - (optional - `js` mode) Name of event dispatched when switching pages
+- `pagination-url` - (`php` mode only) Base URL used for pagination links.
+- `query-param-name` - (optional - `php` mode only) Name of the page query parameter. Defaults to `page`.
+- `:appends` - (optional - `php` mode only) Keyed array of extra query parameters to attach to the pagination URL.
+- `emits` - (optional - `js` mode only) Name of event dispatched when switching pages.
+
+When listening for the page-changed event in `js` mode, you may access the new page via `$event.detail.page`.

--- a/src/Components/Paginators/Base.php
+++ b/src/Components/Paginators/Base.php
@@ -7,35 +7,40 @@ use Illuminate\View\Component;
 
 class Base extends Component
 {
-    public $name;
     public $mode;
     public $numberOfPages;
     public $currentPage;
     public $paginationUrl;
     public $queryParamName;
     public $appends;
+    public $emits;
 
     public function __construct(
-        $name = null,
         $mode = 'php',
         $numberOfPages = 0,
         $currentPage = null,
         $paginationUrl = '#',
         $queryParamName = 'page',
-        $appends = []
+        $appends = [],
+        $emits = 'page-changed'
     ) {
-        $this->name = $name;
         $this->mode = $mode;
         $this->numberOfPages = (int) $numberOfPages;
         $this->currentPage = $currentPage ? (int) $currentPage : 1;
         $this->paginationUrl = $paginationUrl;
         $this->queryParamName = $queryParamName;
         $this->appends = $appends;
+        $this->emits = $emits;
     }
 
     public function inPhpMode(): bool
     {
         return $this->mode === 'php';
+    }
+
+    public function inJsMode(): bool
+    {
+        return $this->mode === 'js';
     }
 
     public function pagePaginationUrl($page)

--- a/src/Components/Paginators/Base.php
+++ b/src/Components/Paginators/Base.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Northeastern\Blade\Components\Paginators;
+
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Component;
+
+class Base extends Component
+{
+    public $name;
+    public $mode;
+    public $numberOfPages;
+    public $currentPage;
+    public $paginationUrl;
+    public $queryParamName;
+    public $appends;
+
+    public function __construct(
+        $name = null,
+        $mode = 'php',
+        $numberOfPages = 0,
+        $currentPage = null,
+        $paginationUrl = '#',
+        $queryParamName = 'page',
+        $appends = []
+    ) {
+        $this->name = $name;
+        $this->mode = $mode;
+        $this->numberOfPages = (int) $numberOfPages;
+        $this->currentPage = $currentPage ? (int) $currentPage : 1;
+        $this->paginationUrl = $paginationUrl;
+        $this->queryParamName = $queryParamName;
+        $this->appends = $appends;
+    }
+
+    public function inPhpMode(): bool
+    {
+        return $this->mode === 'php';
+    }
+
+    public function pagePaginationUrl($page)
+    {
+        if ($page < 1) {
+            return '#';
+        }
+
+        if ($page > $this->numberOfPages) {
+            return '#';
+        }
+
+        if ($this->currentPage === $page) {
+            return '#';
+        }
+
+        $queryParams = collect()
+            ->merge([
+                $this->queryParamName => $page,
+            ])
+            ->merge($this->appends)
+            ->map(function ($queryParamValue, $queryParamName) {
+                return collect()
+                    ->push($queryParamName)
+                    ->push($queryParamValue)
+                    ->join('=');
+            })
+            ->join('&');
+
+        return "{$this->paginationUrl}?{$queryParams}";
+    }
+
+    public function pageClasses($page)
+    {
+        return collect()
+            ->when($page === $this->currentPage, function ($collection) {
+                return $collection->merge([
+                    'inline-flex',
+                    'items-center',
+                    'justify-center',
+                    'w-6',
+                    'h-6',
+                    'text-sm',
+                    'leading-none',
+                    'text-white',
+                    'bg-gray-900',
+                    'rounded-full',
+                    'focus:outline-none',
+                    'focus:ring',
+                    'focus:ring-blue-500',
+                ]);
+            })
+            ->when($page !== $this->currentPage, function ($collection) {
+                return $collection->merge([
+                    'inline-flex',
+                    'items-center',
+                    'justify-center',
+                    'w-6',
+                    'h-6',
+                    'text-sm',
+                    'leading-none',
+                    'rounded-full',
+                    'focus:outline-none',
+                    'focus:ring',
+                    'focus:ring-blue-500',
+                ]);
+            })
+            ->join(' ');
+    }
+
+    public function navigationArrowsClasses($page)
+    {
+        return collect()
+            ->merge([
+                'inline-flex',
+                'items-center',
+                'justify-center',
+                'w-6',
+                'h-6',
+                'text-sm',
+                'leading-none',
+                'rounded-full',
+                'focus:outline-none',
+                'focus:ring',
+                'focus:ring-blue-500',
+            ])
+            ->when(1 > $page || $page > $this->numberOfPages, function ($collection) {
+                return $collection->push('text-gray-300');
+            })
+            ->when(1 < $page && $page < $this->currentPage, function ($collection) {
+                return $collection->push('text-gray-700');
+            })
+            ->join(' ');
+    }
+
+    public function render()
+    {
+        return View::make('kernl-ui::paginators.base');
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -29,6 +29,7 @@ use Northeastern\Blade\Components\Loaders\Dark as LoadersDark;
 use Northeastern\Blade\Components\Loaders\Light as LoadersLight;
 use Northeastern\Blade\Components\LocalHeader;
 use Northeastern\Blade\Components\Modals\Base as ModalsBase;
+use Northeastern\Blade\Components\Paginators\Base as PaginatorBase;
 use Northeastern\Blade\Components\Scripts;
 use Northeastern\Blade\Components\Selects\Select;
 use Northeastern\Blade\Components\Tabs\Bordered as TabsBordered;
@@ -76,5 +77,6 @@ class ServiceProvider extends BaseServiceProvider
         CardLinkWithMediaAndActions::class => 'kernl-cards.link-with-media-and-actions',
         CardEvent::class => 'kernl-cards.event',
         Select::class => 'kernl-selects.select',
+        PaginatorBase::class => 'kernl-paginators.base',
     ];
 }

--- a/src/views/paginators/base.blade.php
+++ b/src/views/paginators/base.blade.php
@@ -1,0 +1,4 @@
+
+@if ($inPhpMode)
+    @include('kernl-ui::paginators.php.base')
+@endif

--- a/src/views/paginators/base.blade.php
+++ b/src/views/paginators/base.blade.php
@@ -1,4 +1,8 @@
 
-@if ($inPhpMode)
+@if ($inPhpMode())
     @include('kernl-ui::paginators.php.base')
+@endif
+
+@if ($inJsMode())
+    @include('kernl-ui::paginators.js.base')
 @endif

--- a/src/views/paginators/js/base.blade.php
+++ b/src/views/paginators/js/base.blade.php
@@ -1,0 +1,36 @@
+<div
+    class="font-sans"
+    x-data="{...basePaginator()}"
+    x-init="
+        numberOfPages = {{ $numberOfPages }}
+        currentPage = {{ $currentPage }}
+        emits = '{{ $emits }}'
+        dispatch = $dispatch
+        init()
+    "
+>
+    <div class="flex items-center justify-center space-x-2">
+        <button
+            x-on:click.stop.prevent="handlePageClick(currentPage - 1)"
+            x-bind:class="navigationArrowClasses(currentPage - 1)"
+        >
+            <i data-feather="chevron-left" class="w-4 h-4"></i>
+        </button>
+
+        <template x-for="page in pages">
+            <button
+                type="button"
+                x-bind:class="pageClasses(page)"
+                x-text="page"
+                x-on:click.stop.prevent="handlePageClick(page)"
+            ></button>
+        </template>
+
+        <button
+            x-on:click.stop.prevent="handlePageClick(currentPage + 1)"
+            x-bind:class="navigationArrowClasses(currentPage + 1)"
+        >
+            <i data-feather="chevron-right" class="w-4 h-4"></i>
+        </button>
+    </div>
+</div>

--- a/src/views/paginators/php/base.blade.php
+++ b/src/views/paginators/php/base.blade.php
@@ -1,4 +1,4 @@
-<div class="px-4 py-32 font-sans">
+<div class="font-sans">
     <div class="flex items-center justify-center space-x-2">
         {{-- Arrow Previous --}}
         <a

--- a/src/views/paginators/php/base.blade.php
+++ b/src/views/paginators/php/base.blade.php
@@ -1,0 +1,29 @@
+<div class="px-4 py-32 font-sans">
+    <div class="flex items-center justify-center space-x-2">
+        {{-- Arrow Previous --}}
+        <a
+            href="{{ $pagePaginationUrl($currentPage - 1) }}"
+            class="{{ $navigationArrowsClasses($currentPage - 1) }}"
+        >
+            <i data-feather="chevron-left" class="w-4 h-4"></i>
+        </a>
+
+
+        @foreach(range(1, $numberOfPages) as $page)
+            <a
+                href="{{ $pagePaginationUrl($page) }}"
+                class="{{ $pageClasses($page) }}"
+            >
+                {{ $page }}
+            </a>
+        @endforeach
+
+        {{-- Arrow Next --}}
+        <a
+            href="{{ $pagePaginationUrl($currentPage + 1) }}"
+            class="{{ $navigationArrowsClasses($currentPage + 1) }}"
+        >
+            <i data-feather="chevron-right" class="w-4 h-4"></i>
+        </a>
+    </div>
+</div>

--- a/src/views/scripts.blade.php
+++ b/src/views/scripts.blade.php
@@ -2,3 +2,4 @@
 @include('kernl-ui::scripts.modals')
 @include('kernl-ui::scripts.tabs')
 @include('kernl-ui::scripts.selects')
+@include('kernl-ui::scripts.paginators')

--- a/src/views/scripts/paginators.blade.php
+++ b/src/views/scripts/paginators.blade.php
@@ -1,0 +1,87 @@
+<script>
+    const basePaginator = () => ({
+        pages: [],
+        numberOfPages: 0,
+        currentPage: 1,
+        emits: 'pageChanged',
+        dispatch: null,
+
+        init() {
+            this.pages = [...Array(this.numberOfPages).keys()].map(page => page + 1)
+        },
+
+        isCurrentPage(page) {
+            return page === this.currentPage
+        },
+
+        handlePageClick(page) {
+            if (page < 1) {
+                return
+            }
+
+            if (page > this.numberOfPages) {
+                return
+            }
+
+            this.currentPage = page
+            this.dispatch(this.emits, {page})
+        },
+
+        pageClasses(page) {
+            return []
+                .concat(this.isCurrentPage(page) ? [
+                    'inline-flex',
+                    'items-center',
+                    'justify-center',
+                    'w-6',
+                    'h-6',
+                    'text-sm',
+                    'leading-none',
+                    'text-white',
+                    'bg-gray-900',
+                    'rounded-full',
+                    'focus:outline-none',
+                    'focus:ring',
+                    'focus:ring-blue-500',
+                ] : [])
+                .concat(!this.isCurrentPage(page) ? [
+                    'inline-flex',
+                    'items-center',
+                    'justify-center',
+                    'w-6',
+                    'h-6',
+                    'text-sm',
+                    'leading-none',
+                    'rounded-full',
+                    'focus:outline-none',
+                    'focus:ring',
+                    'focus:ring-blue-500',
+                ] : [])
+                .join(' ')
+        },
+
+        navigationArrowClasses(page) {
+            return []
+                .concat([
+                    'inline-flex',
+                    'items-center',
+                    'justify-center',
+                    'w-6',
+                    'h-6',
+                    'text-sm',
+                    'leading-none',
+                    'rounded-full',
+                    'focus:outline-none',
+                    'focus:ring',
+                    'focus:ring-blue-500',
+                ])
+                .concat(1 > page || page > this.numberOfPages ? [
+                    'text-gray-300',
+                ] : [])
+                .concat(1 < page && page < this.currentPage ? [
+                    'text-gray-700',
+                ] : [])
+                .join(' ')
+        },
+    })
+</script>


### PR DESCRIPTION
## Summary

This PR adds a new Blade component for Pagination: Base Paginator.

This component supports `php` and `js` mode. In `php` mode, anchors are used for paginating pages. In `js` mode, AlpineJs events are dispatched for other components to use the current page as needed.

## Stories

- https://www.notion.so/nuws/9686730340ce40758017f8c4f7009a68?v=f0ea964fd55b400db6848ab41528922a&p=822849baf4684cd0bb001159278a2d7a

## Usage

![image](https://user-images.githubusercontent.com/5126648/112731013-cbfd1700-8f02-11eb-82b1-62fcd3d1aba0.png)

![image](https://user-images.githubusercontent.com/5126648/112731022-d4ede880-8f02-11eb-8245-da2e206b371a.png)

## Type of Change

- [x] :rocket: New Feature

## Screenshot/Video

![2021-03-27 13 39 13](https://user-images.githubusercontent.com/5126648/112731000-ad971b80-8f02-11eb-828c-4060cfd6c532.gif)

