### PR TITLE
Maintenance: Patching Cards

### DIFF
--- a/src/Components/Cards/LinkWithMedia.php
+++ b/src/Components/Cards/LinkWithMedia.php
@@ -37,7 +37,7 @@ class LinkWithMedia extends Component
             throw new Exception('Provided color is not supported');
         }
 
-        if (! collect(['16:9', '1:1', '4:5', '5:4'])->contains($this->aspectRatio)) {
+        if (! collect(['16:9', '1:1', '3:4', '4:3', '4:5', '5:4'])->contains($this->aspectRatio)) {
             throw new Exception('Aspect ratio is not supported');
         }
     }
@@ -184,14 +184,20 @@ class LinkWithMedia extends Component
             ->when($this->aspectRatio === '1:1', function ($classes) {
                 return $classes->push('aspect-w-1', 'aspect-h-1');
             })
-            ->when($this->aspectRatio === '16:9', function ($classes) {
-                return $classes->push('aspect-w-16', 'aspect-h-9');
+            ->when($this->aspectRatio === '3:4', function ($classes) {
+                return $classes->push('aspect-w-3', 'aspect-h-4');
+            })
+            ->when($this->aspectRatio === '4:3', function ($classes) {
+                return $classes->push('aspect-w-4', 'aspect-h-3');
             })
             ->when($this->aspectRatio === '4:5', function ($classes) {
                 return $classes->push('aspect-w-4', 'aspect-h-5');
             })
             ->when($this->aspectRatio === '5:4', function ($classes) {
                 return $classes->push('aspect-w-5', 'aspect-h-4');
+            })
+            ->when($this->aspectRatio === '16:9', function ($classes) {
+                return $classes->push('aspect-w-16', 'aspect-h-9');
             })
             ->join(' ')
             ;

--- a/src/views/cards/link-with-media-and-actions.blade.php
+++ b/src/views/cards/link-with-media-and-actions.blade.php
@@ -44,7 +44,7 @@
                 @if($secondaryActionText)
                     <a href="{{ $secondaryActionUrl }}" class="ml-1 btn btn-sm text-gray-900 bg-gray-100 hover:bg-gray-300">{{ $secondaryActionText }}</a>
                 @endif
-            </div>
-        @endif
+            @endif
+        </div>
     </div>
 </div>

--- a/src/views/cards/link-with-media.blade.php
+++ b/src/views/cards/link-with-media.blade.php
@@ -1,24 +1,28 @@
 <a
-    href="{{ $url }}"
+    @if (!empty($url))
+        href="{{ $url }}"
+    @endif
     aria-label="{{ $title }}"
     class="{{ $cardClasses() }}"
 >
-    <div class="{{ $imageOuterImageContainerClasses() }}">
-        <div class="{{ $imageInnerImageContainerClasses() }}">
-            <img
-                src="{{ $imageUrl }}"
-                alt="{{ $title }}"
-                class="w-full h-full object-cover transition-opacity group-hover:opacity-80"
-            >
-            @if($badge)
-                <div class="absolute top-0 left-0 px-5 py-6">
-                    <span role="status" class="inline-flex px-4 py-2 text-xs text-white leading-none bg-black bg-opacity-50 rounded-md">
-                        {{ $badge }}
-                    </span>
-                </div>
-            @endif
+    @if ($imageUrl && !empty($imageUrl))
+        <div class="{{ $imageOuterImageContainerClasses() }}">
+            <div class="{{ $imageInnerImageContainerClasses() }}">
+                <img
+                    src="{{ $imageUrl }}"
+                    alt="{{ $title }}"
+                    class="w-full h-full object-cover transition-opacity group-hover:opacity-80"
+                >
+                @if($badge)
+                    <div class="absolute top-0 left-0 px-5 py-6">
+                        <span role="status" class="inline-flex px-4 py-2 text-xs text-white leading-none bg-black bg-opacity-50 rounded-md">
+                            {{ $badge }}
+                        </span>
+                    </div>
+                @endif
+            </div>
         </div>
-    </div>
+    @endif
     <div class="flex flex-col">
 
         <div class="{{ $bodyClasses() }}">


### PR DESCRIPTION
Patching cards to be more flexible.
- Hide image section when no `image-url` is passed to the component
- Allow for 3:4, 4:3 aspect ratios
- Patched `src/views/cards/link-with-media.blade.php` as the `@endif` and `div` needed their placements swapped. 