### PR TITLE
Banners: Updating banner padding and background alpha/opacity

### DIFF
--- a/src/views/banners/with-offset-card.blade.php
+++ b/src/views/banners/with-offset-card.blade.php
@@ -1,6 +1,10 @@
 <div
-    class="py-16 bg-black bg-center bg-cover bg-no-repeat md:py-20"
-    style="background-image: url('{{ $backgroundUrl }}')"
+    class="py-16 md:py-20 lg:py-32 bg-black bg-center bg-cover bg-no-repeat"
+    {!! 
+        $backgroundUrl ? 'style="background-image: 
+        linear-gradient(rgba(0, 0, 0, .5), rgba(0, 0, 0, .5)), 
+        url(' . $backgroundUrl . ')"' : ''
+    !!}
 >
     <div class="container">
         <div class="max-w-2xl px-6 py-12 text-white bg-black bg-opacity-80 lg:px-12 lg:py-16">


### PR DESCRIPTION
 Updating Banner padding to py-32 for large screens, py-20 for medium, and py-16 for all other screen sizes. Setting bg-opacity/alpha to .5 per design sign-off.