### PR TITLE
Hotfix: Removing opacity from with-offset-card banner

### DIFF
--- a/src/views/banners/with-offset-card.blade.php
+++ b/src/views/banners/with-offset-card.blade.php
@@ -1,9 +1,7 @@
 <div
     class="py-16 md:py-20 lg:py-32 bg-black bg-center bg-cover bg-no-repeat"
     {!! 
-        $backgroundUrl ? 'style="background-image: 
-        linear-gradient(rgba(0, 0, 0, .5), rgba(0, 0, 0, .5)), 
-        url(' . $backgroundUrl . ')"' : ''
+        $backgroundUrl ? 'style="background-image: url(' . $backgroundUrl . ')"' : ''
     !!}
 >
     <div class="container">


### PR DESCRIPTION
Updating with-offset-card banner so that background does not have opacity added to it.