### PR TITLE
[Bugfix] Fix Search Icon Alignment

### DIFF
--- a/src/views/menus/desktop-navigation.blade.php
+++ b/src/views/menus/desktop-navigation.blade.php
@@ -3,7 +3,7 @@
         @include('kernl-ui::/menus/support-navigation')
     @endif
     @if ($links)
-        <ul class="-mx-2 flex {{ $supportNav ? 'items-end my-3 text-right' : 'items-center' }}">
+        <ul class="-mx-2 flex {{ $supportNav ? 'items-center my-3 text-right' : 'items-center' }}">
             @foreach ($links as $item)
                 @isset($item['children'])
                     @if(count($item['children']) > 0)

--- a/src/views/menus/mega-menu.blade.php
+++ b/src/views/menus/mega-menu.blade.php
@@ -4,7 +4,7 @@
     @endif
 
     @if ($links)
-        <ul class="-mx-2 flex {{ $supportNav ? 'items-start my-3' : 'items-center' }}">
+        <ul class="-mx-2 flex {{ $supportNav ? 'items-center my-3' : 'items-center' }}">
             @foreach ($links as $item)
                 <div x-data="{isOpen: false} "class="relative" role="listitem">
                     {{-- Mega Menu Item --}}


### PR DESCRIPTION
- Add `items-center` instead of `items-start` to mega-menu
- Add `items-center` instead of `items-end` to desktop-navigation